### PR TITLE
adding gitlab caf module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # terraform-addons-caf
+
 CAF Modules for DevOps Orchestrators

--- a/examples/gitlab/new_project/configuration.tfvars
+++ b/examples/gitlab/new_project/configuration.tfvars
@@ -1,0 +1,6 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "southeastasia"
+  }
+}

--- a/examples/gitlab/new_project/gitlab_project.tfvars
+++ b/examples/gitlab/new_project/gitlab_project.tfvars
@@ -1,0 +1,36 @@
+gitlab_projects = {
+
+  test_project  = {
+    name        = "test_project_10"
+    description = "This is a test!"
+    visibility  = "private"
+
+    variables = {
+      var1 = {
+        value = "testvalue1"
+        protected = true
+        masked = false
+      }
+      var2 = {
+        value = "testvalue2"
+        protected = false
+        masked = true
+      }
+      var3 = {
+        value = "testvalue3"
+        protected = true
+      }
+      var4 = {
+        value = "testvalue4"
+        masked = true
+      }
+    }
+  }
+
+  demo_project  = {
+    name        = "demo_project_20"
+    description = "This is a demo!"
+    visibility  = "private"
+  }
+
+}

--- a/modules/gitlab/README.md
+++ b/modules/gitlab/README.md
@@ -1,0 +1,40 @@
+# GitLab
+
+This submodule is part of Cloud Adoption Framework landing zones for GitLab on Terraform.
+
+You can instantiate this submodule directly using the following parameters:
+
+```
+module "gitlab_projects" {
+  source  = "aztfmod/caf/azurerm/modules/devops/providers/gitlab"
+  version = "3.5.0"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| gitlabhq/gitlab | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project | The project configuration map | `map` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The Project ID. |
+| name | The Project name. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/gitlab/main.tf
+++ b/modules/gitlab/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    gitlab = {
+      source  = "gitlabhq/gitlab"
+      version = ">=3.5.0"
+    }
+  }
+}

--- a/modules/gitlab/output.tf
+++ b/modules/gitlab/output.tf
@@ -1,0 +1,3 @@
+output project_id {
+  value = gitlab_project.project.id
+}

--- a/modules/gitlab/output.tf
+++ b/modules/gitlab/output.tf
@@ -1,3 +1,7 @@
 output project_id {
   value = gitlab_project.project.id
 }
+
+output project_name {
+  value = gitlab_project.project.name
+}

--- a/modules/gitlab/project.tf
+++ b/modules/gitlab/project.tf
@@ -3,3 +3,13 @@ resource "gitlab_project" "project" {
   description        = lookup(var.project, "description", "")
   visibility_level   = lookup(var.project, "visibility", "private")
 }
+
+resource "gitlab_project_variable" "variable" {
+  for_each    = lookup(var.project, "variables", {})
+
+  project   = gitlab_project.project.id
+  key       = each.key
+  value     = lookup(each.value, "value", "")
+  protected = lookup(each.value, "protected", false)
+  masked    = lookup(each.value, "masked", false)
+}

--- a/modules/gitlab/project.tf
+++ b/modules/gitlab/project.tf
@@ -1,0 +1,5 @@
+resource "gitlab_project" "project" {
+  name               = lookup(var.project, "name", "")
+  description        = lookup(var.project, "description", "")
+  visibility_level   = lookup(var.project, "visibility", "private")
+}

--- a/modules/gitlab/variables.tf
+++ b/modules/gitlab/variables.tf
@@ -1,0 +1,3 @@
+variable project {
+  description = "The object representative of the gitlab project entity to update"
+}


### PR DESCRIPTION
Adding [Project Variables]((https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs)) support to GitLab CAF Module (PR #332)

Verified the module by creating couple of new projects by following the below steps;

```bash
export environment=demo
export GITLAB_TOKEN=<token created at gitlab.com / or gitlab server>
# run the following command if you're using gitlab server
export GITLAB_BASE_URL=<url of the gitlab server>

rover -lz /tf/caf/public/landingzones/caf_launchpad -launchpad -var-folder /tf/caf/configuration/${environment}/level0/launchpad -parallelism 30 -level level0 -env ${environment} -a apply

rover -lz /tf/modules/examples/ -var-folder /tf/modules/examples/devops/providers/gitlab/new_project/  -level level1 -env ${environment} -a apply
```

After it finish running (it may take couple of minutes) you'll see couple of projects in your gitlab instance;

![image](https://user-images.githubusercontent.com/118744/111433736-ba9c5980-870f-11eb-8f72-3e98835321b5.png)

_PS : I used the following configuration;_

```terraform
gitlab_projects = {

  test_project  = {
    name        = "test_project_2"
    description = "updated test project description"
    visibility  = "private"

    variables = {
      var1 = {
        value = "testvalue1"
        protected = true
        masked = false
      }
      var2 = {
        value = "testvalue2"
        protected = false
        masked = true
      }
      var3 = {
        value = "testvalue3"
        protected = true
      }
      var4 = {
        value = "testvalue4"
        masked = true
      }
    }
  }

  demo_project  = {
    name        = "test_project_3"
    description = "test project description"
    visibility  = "private"
  }

}
```
